### PR TITLE
Fix for getting semver during make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER_IMAGE ?= containersol/externalsecret-operator
-DOCKER_TAG ?= $(shell grep -Po 'Version = "\K.*?(?=")' version/version.go)
+DOCKER_TAG ?= $(shell go run version/version.go)
 
 # export these if you want to use AWS secrets manager
 AWS_ACCESS_KEY_ID ?= AKIACONFIGUREME

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,12 @@
-package version
+package main
+
+import "fmt"
 
 var (
+	// Version Semantion version
 	Version = "0.0.1"
 )
+
+func main() {
+	fmt.Println(Version)
+}


### PR DESCRIPTION
Grep command for obtaining semantic version of code for docker images (`grep -Po ...`) is not OS portable (doesn't work on OSX):

```
$make build
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
operator-sdk build containersol/externalsecret-operator:
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
```

Implemented a solution that does not depend on grep.
