### PR TITLE
switch to registry.access.redhat.com/ubi7/ubi-minimal:7.6

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.6
 
 RUN microdnf install unzip -y
 


### PR DESCRIPTION
See:

https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image