### PR TITLE
Fix leader election

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,6 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+const (
+	operatorDefaultName = "externalsecret-operator"
+)
+
 // Change below variables to serve metrics on different host or port.
 var (
 	metricsHost       = "0.0.0.0"
@@ -86,7 +90,11 @@ func main() {
 	ctx := context.TODO()
 
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "externalsecret-operator-lock")
+	operatorName := os.Getenv("OPERATOR_NAME")
+	if len(operatorName) == 0 {
+		operatorName = operatorDefaultName
+	}
+	err = leader.Become(ctx, operatorName+"-lock")
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)


### PR DESCRIPTION
Prevent multiple instances of the same operator to share the same lock when running in the same namespace by using `OPERATOR_NAME` as part of the lock ID. If `OPERATOR_NAME` is not specified then `externalsecret-operator-lock` will be used instead.

Given two operators deployed in the same namespace:

```shell
helm upgrade --install dummy1 --wait \
    --namespace operators \
    --set watchNamespace="dev1" \
    --set crds.create=false \
    --set secret.data.Name="dummy1" \
    --set secret.data.Type="dummy" \
    --set secret.data.Parameters.suffix="-dummy1" \
    ./deploy/helm/.

helm upgrade --install dummy2 --wait \
    --namespace operators \
    --set watchNamespace="dev2" \
    --set crds.create=false \
    --set secret.data.Name="dummy2" \
    --set secret.data.Type="dummy" \
    --set secret.data.Parameters.suffix="-dummy2" \
    ./deploy/helm/.
```

They will have each their own lock:
```shell
% kubectl get configmaps -n operators
NAME                                  DATA   AGE
dummy1-externalsecret-operator-lock   0      46s
dummy2-externalsecret-operator-lock   0      44s

```