### PR TITLE
Unify operator name and backend name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ AWS_DEFAULT_REGION ?= eu-west-1
 
 NAMESPACE ?= "default"
 BACKEND ?= "asm"
+OPERATOR_NAME ?= "asm-example"
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ export AWS_ACCESS_KEY_ID="AKIAYOURSECRETKEYID"
 export AWS_DEFAULT_REGION="eu-west-1"
 export AWS_SECRET_ACCESS_KEY="OoXie5Mai6Qu3fakemeezoo4ahfoo6IHahch0rai"
 helm upgrade --install asm1 --wait \
-    --set secret.data.Name="asm-example" \
+    --set operatorName="asm-example" \
     --set secret.data.Type="asm" \
     --set secret.data.Parameters.accessKeyID="$AWS_ACCESS_KEY_ID" \
     --set secret.data.Parameters.region="$AWS_DEFAULT_REGION" \
@@ -39,7 +39,8 @@ manifests for you. The following command will deploy the operator in the
 export AWS_ACCESS_KEY_ID="AKIAYOURSECRETKEYID"
 export AWS_DEFAULT_REGION="eu-west-1"
 export AWS_SECRET_ACCESS_KEY="OoXie5Mai6Qu3fakemeezoo4ahfoo6IHahch0rai"
-export BACKENDS=asm
+export OPERATOR_NAME=asm-example
+export BACKEND=asm
 make deploy
 ```
 It will watch for `ExternalSecrets` with `Backend: asm-example` resources in the `default` namespace and it will inject a corresponding `Secret` with the value retrieved from AWS Secret Manager.
@@ -64,7 +65,7 @@ metadata:
   name: example-externalsecret
 spec:
   Key: example-externalsecret-key
-  Backend: asm
+  Backend: asm-example
 ```
 
 The operator fetches the secret from AWS Secrets Manager and injects it as a

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -90,10 +90,7 @@ func main() {
 	ctx := context.TODO()
 
 	// Become the leader before proceeding
-	operatorName := os.Getenv("OPERATOR_NAME")
-	if len(operatorName) == 0 {
-		operatorName = operatorDefaultName
-	}
+	operatorName, _ := k8sutil.GetOperatorName()
 	err = leader.Become(ctx, operatorName+"-lock")
 	if err != nil {
 		log.Error(err, "")

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: externalsecret-operator
       containers:
         - name: externalsecret-operator
-          image: containersol/externalsecret-operator:${DOCKER_TAG}
+          image: ${DOCKER_IMAGE}
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -25,7 +25,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "externalsecret-operator"
+              value: ${OPERATOR_NAME}
             - name: OPERATOR_CONFIG
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -18,7 +18,7 @@ This chart will create:
 
 4. A [ServiceAccount](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) (optional) which will be used by the External Secret Operator
 
-5. Two [Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)/[RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) pairs (optional), one to restrict the actions the External Secret Operator caniperform in the namespace in which is running and the other to restrict the operations it can perform in the namespace which is watching  
+5. Two [Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)/[RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) pairs (optional), one to restrict the actions the External Secret Operator caniperform in the namespace in which is running and the other to restrict the operations it can perform in the namespace which is watching
 
 ### Installation
 
@@ -26,7 +26,7 @@ The following command will install the Exernal Secret Operator using the AWS Sec
 
 ```shell
 helm upgrade --install asm1 --wait \
-    --set secret.data.Name="asm-example" \
+    --set operatorName="asm-example" \
     --set secret.data.Type="asm" \
     --set secret.data.Parameters.accessKeyID="$AWS_ACCESS_KEY_ID" \
     --set secret.data.Parameters.region="$AWS_DEFAULT_REGION" \
@@ -45,7 +45,7 @@ You can provide the configuration of the External Secret Operator using the `sec
 | `image.tag` | Image tag | `0.2.0`
 | `image.pullPolicy` | Image pull policy | `IfNotPresent`
 | `watchNamespace` | Namespace to watch for `ExternalSecret` resources. If empty, will be the same as the one where the operator will be deployed | `""`
-| `operatorName` | Name passed as `OPERATOR_NAME` environment variable | `externalsecret-operator`
+| `operatorName` | Name passed as `OPERATOR_NAME` environment variable. Referenced by `ExternalSecret` resources in `Backend` field | `externalsecret-operator`
 | `crds.create` | Whether `ExternalSecret` CRD should be created | `true`
 | `secret.create` | Whether the secret containing the operator configuration should be created | `true`
 | `secret.name` | Name of the Secret that contains the operator configuration. If empty and `secret.create` is `true`, a secret based on the release name will be generated | `""`
@@ -58,7 +58,6 @@ The following default configuration is added in the secret if no other is specif
 
 ```yaml
 data:
-  Name: "dummy-example"
   Type: "dummy"
   Parameters:
     suffix: "-externalsecretsoperatorwashere"

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -8,6 +8,6 @@ metadata:
   name: example-externalsecret-{{ .Values.secret.data.Type }}
 spec:
   Key: example-externalsecret-key
-  Backend: {{ .Values.secret.data.Name }}
+  Backend: {{ .Values.operatorName }}
 {{- else }}
 {{- end -}}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -9,7 +9,11 @@ image:
   tag: 0.0.2
   pullPolicy: IfNotPresent
 
+# The namespace that will be watched for ExternalSecret resources
 watchNamespace: ""
+
+# The name for this operator, must be referenced by ExternalSecret resources
+# as the Backend field
 operatorName: externalsecret-operator
 
 crds:
@@ -26,7 +30,6 @@ secret:
   # The content of the secret.
   # If create is true, is going to be converted to JSON and added to the secret
   data:
-    Name: "dummy-example"
     Type: "dummy"
     Parameters:
       suffix: "-externalsecretsoperatorwashere"

--- a/deploy/secret-asm.yaml
+++ b/deploy/secret-asm.yaml
@@ -6,7 +6,6 @@ type: Opaque
 stringData:
   operator-config.json: |-
     {
-      "Name": "asm-example",
       "Type": "asm",
       "Parameters": {
         "accessKeyID": "$AWS_ACCESS_KEY_ID",

--- a/deploy/secret-dummy.yaml
+++ b/deploy/secret-dummy.yaml
@@ -6,7 +6,6 @@ type: Opaque
 stringData:
   operator-config.json: |-
     {
-      "Name": "dummy-example",
       "Type": "dummy",
       "Parameters": {
         "Suffix": "-dummyexample"

--- a/deploy/secret-onepassword.yaml
+++ b/deploy/secret-onepassword.yaml
@@ -6,7 +6,6 @@ type: Opaque
 stringData:
   operator-config.json: |-
     {
-      "Name": "onepassword",
       "Type": "onepassword",
       "Parameters": {
         "domain": "${OP_DOMAIN}",

--- a/deploy/source-onepassword-secrets.sh
+++ b/deploy/source-onepassword-secrets.sh
@@ -9,4 +9,5 @@ export OP_MASTER_PASSWORD=$(echo $OP_ITEM_JSON | jq -r '.details.fields[] | sele
 export OP_VAULT="test vault one"
 export BACKEND="onepassword"
 
-export OPERATOR_CONFIG="{ \"Name\": \"onepassword\", \"Type\": \"onepassword\", \"Parameters\": {\"domain\": \"${OP_DOMAIN}\", \"email\": \"${OP_EMAIL}\", \"secretKey\": \"${OP_SECRET_KEY}\", \"masterPassword\": \"${OP_MASTER_PASSWORD}\", \"vault\": \"${OP_VAULT}\" }}"
+export OPERATOR_CONFIG="{\"Type\": \"onepassword\", \"Parameters\": {\"domain\": \"${OP_DOMAIN}\", \"email\": \"${OP_EMAIL}\", \"secretKey\": \"${OP_SECRET_KEY}\", \"masterPassword\": \"${OP_MASTER_PASSWORD}\", \"vault\": \"${OP_VAULT}\" }}"
+export OPERATOR_NAME="onepassword"

--- a/secrets/backend/backend.go
+++ b/secrets/backend/backend.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -63,13 +65,18 @@ func InitFromEnv() error {
 		return err
 	}
 
-	err = Instantiate(config.Name, config.Type)
+	operatorName, err := k8sutil.GetOperatorName()
 	if err != nil {
 		return err
 	}
 
-	log.Info("initialize", "name", config.Name)
-	err = Instances[config.Name].Init(config.Parameters)
+	err = Instantiate(operatorName, config.Type)
+	if err != nil {
+		return err
+	}
+
+	log.Info("initialize", "name", operatorName)
+	err = Instances[operatorName].Init(config.Parameters)
 
 	return err
 }

--- a/secrets/backend/backend_test.go
+++ b/secrets/backend/backend_test.go
@@ -64,7 +64,6 @@ func TestInstantiate(t *testing.T) {
 func TestInitFromEnv(t *testing.T) {
 
 	configStruct := Config{
-		Name: "mock-backend",
 		Type: "mock",
 		Parameters: map[string]string{
 			"Param1": "Value1",
@@ -76,6 +75,7 @@ func TestInitFromEnv(t *testing.T) {
 		Convey("Given a valid config", func() {
 			configData, _ := json.Marshal(configStruct)
 			os.Setenv("OPERATOR_CONFIG", string(configData))
+			os.Setenv("OPERATOR_NAME", "mock-backend")
 			Convey("When initializing backend from env", func() {
 				err := InitFromEnv()
 				So(err, ShouldBeNil)
@@ -89,15 +89,29 @@ func TestInitFromEnv(t *testing.T) {
 			})
 		})
 
-		Convey("Given a valid config with unknown backend type ", func() {
-			configStruct.Type = "unknown"
+		Convey("Given a valid config but no OPERATOR_NAME", func() {
 			configData, _ := json.Marshal(configStruct)
 			os.Setenv("OPERATOR_CONFIG", string(configData))
+			os.Unsetenv("OPERATOR_NAME")
 			Convey("When initializing backend from env", func() {
 				err := InitFromEnv()
 				So(err, ShouldNotBeNil)
 				Convey("Then an error message is returned", func() {
-					So(err.Error(), ShouldStartWith, "unknown backend type")
+					So(err.Error(), ShouldStartWith, "OPERATOR_NAME must be set")
+				})
+			})
+		})
+
+		Convey("Given a valid config with unknown backend type ", func() {
+			configStruct.Type = "unknown"
+			configData, _ := json.Marshal(configStruct)
+			os.Setenv("OPERATOR_CONFIG", string(configData))
+			os.Setenv("OPERATOR_NAME", "mock-backend")
+			Convey("When initializing backend from env", func() {
+				err := InitFromEnv()
+				So(err, ShouldNotBeNil)
+				Convey("Then an error message is returned", func() {
+					So(err.Error(), ShouldEqual, "unknown backend type: 'unknown'")
 				})
 			})
 		})

--- a/secrets/backend/config.go
+++ b/secrets/backend/config.go
@@ -11,7 +11,6 @@ const ConfigEnvVar string = "OPERATOR_CONFIG"
 
 //Config represent configuration information for the secrets backend
 type Config struct {
-	Name       string
 	Type       string
 	Parameters map[string]string
 }

--- a/secrets/backend/config_test.go
+++ b/secrets/backend/config_test.go
@@ -9,7 +9,6 @@ import (
 func TestBackendConfigFromJSON(t *testing.T) {
 	Convey("Given a JSON backend config string", t, func() {
 		configData := `{
-			 "Name": "dummy-example",
 			 "Type": "dummy",
 			 "Parameters": {
          "Suffix": "-ohlord"
@@ -20,7 +19,6 @@ func TestBackendConfigFromJSON(t *testing.T) {
 			backendConfig, err := ConfigFromJSON(configData)
 			So(err, ShouldBeNil)
 			Convey("The data in Config is as expected", func() {
-				So(backendConfig.Name, ShouldEqual, "dummy-example")
 				So(backendConfig.Type, ShouldEqual, "dummy")
 				So(backendConfig.Parameters, ShouldResemble, map[string]string{"Suffix": "-ohlord"})
 			})


### PR DESCRIPTION
Use `OPERATOR_NAME` environment variable as Backend name. See #64 .

I think it shouldn't have any negative impact on the onepassword backend, but please review.