### PR TITLE
Introduce integration testing using k3s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
 
 jobs:
+
   test:
     docker:
       - image: circleci/golang:1.11
@@ -9,19 +10,13 @@ jobs:
     working_directory: /go/src/github.com/ContainerSolutions/externalsecret-operator
     steps:
       - checkout
-      - run: make test
-
-  coverage:
-    docker:
-      - image: circleci/golang:1.11
-        environment:
-          GO111MODULE: "on"
-    working_directory: /go/src/github.com/ContainerSolutions/externalsecret-operator
-    steps:
-      - checkout
+      - setup_remote_docker
+      - run: |
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run: make coverage
+      - run: make push
 
-  test-helm:
+  helm:
     machine:
       image: circleci/classic:201808-01
     environment:
@@ -29,7 +24,6 @@ jobs:
       INSTALL_K3S_VERSION: "v1.0.0"
       INSTALL_K3S_EXEC: "--write-kubeconfig-mode 664 --docker"
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-      DOCKER_TAG: latest
 
     working_directory: ~/k3s-circleci
     steps:
@@ -56,7 +50,7 @@ jobs:
             kubectl --namespace=kube-system wait --for=condition=Available --timeout=5m apiservices/v1beta1.metrics.k8s.io
             PATH="$(pwd)/linux-amd64:$PATH" make test-helm
 
-  push:
+  release:
     docker:
       - image: circleci/golang:1.11
         environment:
@@ -67,18 +61,17 @@ jobs:
       - setup_remote_docker
       - run: |
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-      - run: make build
-      - run: make push
+      - run: make release
+
 
 workflows:
   version: 2
   build:
     jobs:
       - test
-      - coverage
-      - test-helm
-      - push:
+      - helm:
           requires:
             - test
-            - coverage
-            - test-helm
+      - release:
+          requires:
+            - helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,63 @@ jobs:
     docker:
       - image: circleci/golang:1.11
         environment:
-          GO111MODULE: "on"      
-    working_directory: /go/src/github.com/ContainerSolutions/externalsecret-operator          
+          GO111MODULE: "on"
+    working_directory: /go/src/github.com/ContainerSolutions/externalsecret-operator
     steps:
       - checkout
       - run: make test
+
+  coverage:
+    docker:
+      - image: circleci/golang:1.11
+        environment:
+          GO111MODULE: "on"
+    working_directory: /go/src/github.com/ContainerSolutions/externalsecret-operator
+    steps:
+      - checkout
       - run: make coverage
+
+  test-helm:
+    machine:
+      image: circleci/classic:201808-01
+    environment:
+      HELM_VERSION: "v3.0.0"
+      INSTALL_K3S_VERSION: "v1.0.0"
+      INSTALL_K3S_EXEC: "--write-kubeconfig-mode 664 --docker"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      DOCKER_TAG: latest
+
+    working_directory: ~/k3s-circleci
+    steps:
+      - checkout
+      - run:
+          name: Install k3s cluster
+          command: |
+            curl -sfL https://get.k3s.io | sh -
+            sudo chmod -R a+rw /etc/rancher/k3s
+      - run:
+          name: Install helm
+          command: |
+            curl -sLo helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
+            tar xzf helm.tar.gz
+            chmod +x linux-amd64/helm
+      - run:
+          name: Run test-helm
+          command: |
+            # make sure k3s is ready
+            while [ ! "$(kubectl get node | grep Ready)" ] ; do sleep 1 ; done
+            # make extra sure k3s is ready
+            sleep 5
+            # make extra extra sure k3s is ready https://github.com/helm/helm/issues/6361
+            kubectl --namespace=kube-system wait --for=condition=Available --timeout=5m apiservices/v1beta1.metrics.k8s.io
+            PATH="$(pwd)/linux-amd64:$PATH" make test-helm
 
   push:
     docker:
       - image: circleci/golang:1.11
         environment:
           GO111MODULE: "on"
-    working_directory: /go/src/github.com/ContainerSolutions/externalsecret-operator                    
+    working_directory: /go/src/github.com/ContainerSolutions/externalsecret-operator
     steps:
       - checkout
       - setup_remote_docker
@@ -31,6 +75,10 @@ workflows:
   build:
     jobs:
       - test
+      - coverage
+      - test-helm
       - push:
           requires:
             - test
+            - coverage
+            - test-helm

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OPERATOR_NAME ?= "asm-example"
 GIT_HASH	:= $(shell git rev-parse --short HEAD)
 GIT_BRANCH 	:= $(shell git rev-parse --abbrev-ref HEAD | sed 's/\//-/')
 GIT_TAG 	:= $(shell git describe --tags --abbrev=0 --always)
-DOCKER_TAG 	:= $(shell ./build/scripts/determine_docker_tag.sh $(GIT_HASH) $(GIT_BRANCH) $(GIT_TAG))
+DOCKER_TAG 	?= $(shell ./build/scripts/determine_docker_tag.sh $(GIT_HASH) $(GIT_BRANCH) $(GIT_TAG))
 
 .PHONY: build
 build: operator-sdk
@@ -80,8 +80,9 @@ OPERATOR_NAME=$(RELEASE)
 BACKEND=dummy
 .EXPORT_ALL_VARIABLES: test-helm
 test-helm:
-	helm upgrade --install --wait $(RELEASE) \
+	helm install --wait $(RELEASE) \
 		--set test.create=true \
+		--set image.tag=$(DOCKER_TAG) \
 		./deployments/helm/externalsecret-operator/.
 	helm test  $(RELEASE)
 	helm uninstall $(RELEASE)


### PR DESCRIPTION
This PR introduces testing using k3s and the provided helm chart.

Notice that this test is useful even if your are not using helm in your secret backend implementation as the only test included in helm is currently using the `dummy` backend and essentially just verifies the core secret injection functionality is still working.

To deploy to a k3s cluster I needed to decouple the `push` stage from the `release` one. With this change, every commits generates an image, this allows me to easily pull that from the k3s cluster. The `release` stage uses the same tagging logic (`<branch-name>-latest` for branches, `<tag>` for tags and `latest` for master).

I am not 100% with running time and there's a lot of caching that could still be exploited, I am sure, but I still think is a good addition.