### PR TITLE
Add support for AWS SDK default config loading order

### DIFF
--- a/pkg/asm/backend_test.go
+++ b/pkg/asm/backend_test.go
@@ -1,9 +1,10 @@
 package asm
 
 import (
+	"errors"
+	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	. "github.com/smartystreets/goconvey/convey"
@@ -11,6 +12,7 @@ import (
 
 type mockedSecretsManager struct {
 	secretsmanageriface.SecretsManagerAPI
+	withError bool
 }
 
 func (m *mockedSecretsManager) GetSecretValue(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
@@ -19,13 +21,35 @@ func (m *mockedSecretsManager) GetSecretValue(input *secretsmanager.GetSecretVal
 		Name:         input.SecretId,
 		SecretString: &mockSecretString,
 	}
+	if m.withError {
+		return output, errors.New("oops")
+	}
 	return output, nil
+}
+
+func TestNewBackend(t *testing.T) {
+	Convey("When creating a new ASM backend", t, func() {
+		backend := NewBackend()
+		So(backend, ShouldNotBeNil)
+		So(backend, ShouldHaveSameTypeAs, &Backend{})
+	})
 }
 
 func TestGet(t *testing.T) {
 	secretKey := "secret"
 	secretValue := "secretValue"
 	expectedValue := secretValue
+
+	Convey("Given an uninitialized AWSSecretsManagerBackend", t, func() {
+		backend := Backend{}
+		Convey("When retrieving a secret", func() {
+			_, err := backend.Get(secretKey)
+			Convey("Then an error is returned", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "backend not initialized")
+			})
+		})
+	})
 
 	Convey("Given an initialized AWSSecretsManagerBackend", t, func() {
 		backend := Backend{}
@@ -38,9 +62,21 @@ func TestGet(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Given an initialized AWSSecretsManagerBackend (withError: true)", t, func() {
+		backend := Backend{}
+		backend.SecretsManager = &mockedSecretsManager{withError: true}
+		Convey("When retrieving a secret", func() {
+			_, err := backend.Get(secretKey)
+			Convey("Then an error is returned", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
 }
 
-type parametersTest struct {
+type envVariablesTest struct {
+	envVariables            map[string]string
 	parameters              map[string]string
 	expectedAccessKeyID     string
 	expectedRegion          string
@@ -49,78 +85,67 @@ type parametersTest struct {
 	expectedErrorString     string
 }
 
-func TestAWSConfigFromParams(t *testing.T) {
-	expectedAccessKeyID := "AKIABLABLA"
-	expectedSecretAccessKey := "SMAMSLscSercreasdas"
-	expectedRegion := "eu-west-1"
+func TestInit(t *testing.T) {
+	// https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 
-	tests := []parametersTest{
+	tests := []envVariablesTest{
 		{
-			parameters: map[string]string{
-				"accessKeyID":     expectedAccessKeyID,
-				"region":          expectedRegion,
-				"secretAccessKey": expectedSecretAccessKey,
+			envVariables: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "AKIABLABLA",
+				"AWS_REGION":            "eu-mediterranean-1",
+				"AWS_SECRET_ACCESS_KEY": "SMMSsecrets",
 			},
-			expectedAccessKeyID:     expectedAccessKeyID,
-			expectedRegion:          expectedRegion,
-			expectedSecretAccessKey: expectedSecretAccessKey,
-			expectedErrorAssertion:  ShouldBeNil,
-		},
-
-		{
-			parameters: map[string]string{
-				"accessKeyID":     expectedAccessKeyID,
-				"secretAccessKey": expectedSecretAccessKey,
-			},
-			expectedAccessKeyID:     expectedAccessKeyID,
-			expectedRegion:          expectedRegion,
-			expectedSecretAccessKey: expectedSecretAccessKey,
-			expectedErrorAssertion:  ShouldNotBeNil,
-			expectedErrorString:     "Invalid init parameters: expected `region` not found",
+			parameters:              nil,
+			expectedAccessKeyID:     "AKIABLABLA",
+			expectedRegion:          "eu-mediterranean-1",
+			expectedSecretAccessKey: "SMMSsecrets",
 		},
 		{
-			parameters: map[string]string{
-				"region":          expectedRegion,
-				"secretAccessKey": expectedSecretAccessKey,
+			envVariables: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "AKIABLABLA",
+				"AWS_REGION":            "eu-mediterranean-1",
+				"AWS_SECRET_ACCESS_KEY": "SMMSsecrets",
 			},
-			expectedAccessKeyID:     expectedAccessKeyID,
-			expectedRegion:          expectedRegion,
-			expectedSecretAccessKey: expectedSecretAccessKey,
-			expectedErrorAssertion:  ShouldNotBeNil,
-			expectedErrorString:     "Invalid init parameters: expected `accessKeyID` not found",
+			parameters:              map[string]string{},
+			expectedAccessKeyID:     "AKIABLABLA",
+			expectedRegion:          "eu-mediterranean-1",
+			expectedSecretAccessKey: "SMMSsecrets",
 		},
-
 		{
-			parameters: map[string]string{
-				"accessKeyID": expectedAccessKeyID,
-				"region":      expectedRegion,
+			envVariables: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "AKIABLABLA",
+				"AWS_SECRET_ACCESS_KEY": "eu-mediterranean-1",
+				"AWS_REGION":            "SMMSsecrets",
 			},
-			expectedAccessKeyID:     expectedAccessKeyID,
-			expectedRegion:          expectedRegion,
-			expectedSecretAccessKey: expectedSecretAccessKey,
-			expectedErrorAssertion:  ShouldNotBeNil,
-			expectedErrorString:     "Invalid init parameters: expected `secretAccessKey` not found",
+			parameters: map[string]string{
+				"accessKeyID":     "some",
+				"region":          "other",
+				"secretAccessKey": "value",
+			},
+			expectedAccessKeyID:     "some",
+			expectedRegion:          "other",
+			expectedSecretAccessKey: "value",
 		},
 	}
 
 	for _, test := range tests {
-		Convey("Given a set of params", t, func() {
-			Convey("When creating AWS Config from them", func() {
-				config, err := awsConfigFromParams(test.parameters)
-				So(err, test.expectedErrorAssertion)
-				if err != nil {
-					So(err.Error(), ShouldEqual, test.expectedErrorString)
-				} else {
-					Convey("Credentials are created correctly", func() {
-						actualCredentials, err := config.Credentials.Get()
-						So(err, ShouldBeNil)
-						So(aws.StringValue(config.Region), ShouldEqual, test.expectedRegion)
-						So(actualCredentials.AccessKeyID, ShouldEqual, test.expectedAccessKeyID)
-						So(actualCredentials.SecretAccessKey, ShouldEqual, test.expectedSecretAccessKey)
-					})
-				}
+		Convey("Given AWS credentials using environment variables", t, func() {
+			for k, v := range test.envVariables {
+				os.Setenv(k, v)
+			}
+			Convey("When initializing an ASM backend", func() {
+				b := Backend{}
+				err := b.Init(test.parameters)
+				So(err, ShouldBeNil)
+				Convey("Then credentials are reflected in the AWS session", func() {
+					actualCredentials, err := b.session.Config.Credentials.Get()
+					So(err, ShouldBeNil)
+					So(*b.session.Config.Region, ShouldEqual, test.expectedRegion)
+					So(actualCredentials.AccessKeyID, ShouldEqual, test.expectedAccessKeyID)
+					So(actualCredentials.SecretAccessKey, ShouldEqual, test.expectedSecretAccessKey)
+				})
 			})
+
 		})
 	}
-
 }


### PR DESCRIPTION
Currently we support configuration passed only as parameter JSON file for ASM backend.

This PR lets kick in the default credential loading specified here https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ if parameter configuration fails.

Additionally, this PR restructures some tests in order to increase code coverage.