### PR TITLE
Push image to registry only when building `master`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
       id: prep
       run: |
         DOCKER_IMAGE=containersol/externalsecret-operator
+
         VERSION=edge
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}
@@ -65,13 +66,24 @@ jobs:
         elif [[ $GITHUB_REF == refs/pull/* ]]; then
           VERSION=pr-${{ github.event.number }}
         fi
+
         TAGS="${DOCKER_IMAGE}:${VERSION}"
         if [ "${{ github.event_name }}" = "push" ]; then
           TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
         fi
+
+        # Only push the image to Docker Hub if we're not building a fork
+        if [[ ${{ github.event.pull_request.head.repo.full_name }} == ContainerSolutions/externalsecret-operator ]]; then
+          PUSH_IMAGE=true
+        else
+          PUSH_IMAGE=false
+        fi
+
         echo ::set-output name=version::${VERSION}
         echo ::set-output name=tags::${TAGS}
         echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        echo ::set-output name=push_image::$PUSH_IMAGE
+
     - name: Check out the repo
       uses: actions/checkout@v2
       
@@ -91,6 +103,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
+      if: ${{ steps.prep.outputs.push_image == 'true' }}
 
     - name: Build and push
       id: docker_build
@@ -101,7 +114,7 @@ jobs:
         builder: ${{ steps.buildx.outputs.name }}
         platforms: linux/amd64,linux/arm/v7,linux/arm64
         tags: ${{ steps.prep.outputs.tags }}
-        push: true
+        push: ${{ steps.prep.outputs.push_image }}
         labels: |
           org.opencontainers.image.source=${{ github.event.repository.clone_url }}
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}


### PR DESCRIPTION
I noticed the builds were failing recently. :x: :cry:  
It looks like it's trying to always login to Docker Hub, even for PRs, which shouldn't need to push any image.

This PR adds a check to see if we're building off `master`, and if we're not, then it skips the `docker login` step and the push step.

Thanks for maintaining this!