### PR TITLE
Fix CI bug that prevents non-forked branches from being pushed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,11 +72,12 @@ jobs:
           TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
         fi
 
-        # Only push the image to Docker Hub if we're not building a fork
-        if [[ ${{ github.event.pull_request.head.repo.full_name }} == ContainerSolutions/externalsecret-operator ]]; then
-          PUSH_IMAGE=true
-        else
-          PUSH_IMAGE=false
+        PUSH_IMAGE=true
+        # If this is both a pull request and a fork, then don't push the image
+        if [[ ${{ github.event_name }} == pull_request ]]; then
+          if [[ ${{ github.event.pull_request.head.repo.full_name }} != ContainerSolutions/externalsecret-operator ]]; then
+            PUSH_IMAGE=false
+          fi
         fi
 
         echo ::set-output name=version::${VERSION}


### PR DESCRIPTION
Addresses #115

I started adding another condition to that `if` statement, but noticed it would be less complex to set `PUSH_IMAGE` to true by default, and only make it false if the PR head is not `ContainerSolutions/externalsecret-operator`. How does that sound? 