### PR TITLE
Remove `---` from status keys in CRD yaml specs (Fixes #152)

### DIFF
--- a/config/crd/bases/secrets.externalsecret-operator.container-solutions.com_externalsecrets.yaml
+++ b/config/crd/bases/secrets.externalsecret-operator.container-solutions.com_externalsecrets.yaml
@@ -92,7 +92,7 @@ spec:
                 of an object's state
               items:
                 description: "Condition contains details for one aspect of the current
-                  state of this API Resource. --- This struct is intended for direct
+                  state of this API Resource. This struct is intended for direct
                   use as an array at the field path .status.conditions.  For example,
                   type FooStatus struct{     // Represents the observations of a foo's
                   current state.     // Known .status.conditions.type are: \"Available\",
@@ -143,7 +143,7 @@ spec:
                     type: string
                   type:
                     description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      --- Many .condition.type values are consistent across resources
+                      Many .condition.type values are consistent across resources
                       like Available, but because arbitrary conditions can be useful
                       (see .node.status.conditions), the ability to deconflict is
                       important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)

--- a/config/crd/bases/store.externalsecret-operator.container-solutions.com_secretstores.yaml
+++ b/config/crd/bases/store.externalsecret-operator.container-solutions.com_secretstores.yaml
@@ -55,7 +55,7 @@ spec:
                 of an object's state
               items:
                 description: "Condition contains details for one aspect of the current
-                  state of this API Resource. --- This struct is intended for direct
+                  state of this API Resource. This struct is intended for direct
                   use as an array at the field path .status.conditions.  For example,
                   type FooStatus struct{     // Represents the observations of a foo's
                   current state.     // Known .status.conditions.type are: \"Available\",
@@ -106,7 +106,7 @@ spec:
                     type: string
                   type:
                     description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      --- Many .condition.type values are consistent across resources
+                      Many .condition.type values are consistent across resources
                       like Available, but because arbitrary conditions can be useful
                       (see .node.status.conditions), the ability to deconflict is
                       important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)


### PR DESCRIPTION
### What changes were proposed in this pull request?
- To remove `---` marks from CRD yaml definitions (located in `config/crd/bases`)

### Why are the changes needed?
- This fixes the `doc.crds.dev` parsing. You might check the result [here](https://doc.crds.dev/github.com/DylanGuedes/externalsecret-operator)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I validated in my local fork that `doc.crds.dev` is parsing fine with the new changes